### PR TITLE
Agregar firmantes cuando tenga sólo el archivo

### DIFF
--- a/MifielAPI/MifielAPI/Dao/Documents.cs
+++ b/MifielAPI/MifielAPI/Dao/Documents.cs
@@ -92,9 +92,20 @@ namespace MifielAPI.Dao
                 pdfContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/pdf");
 
                 multipartContent.Add(pdfContent, "file", Path.GetFileName(filePath));
+
+                if (signatures != null)
+                {
+                    for (int i = 0; i < signatures.Count; i++)
+                    {
+                        multipartContent.Add(new StringContent(signatures[i].SignatureStr), "signatories[" + i + "][name]");
+                        multipartContent.Add(new StringContent(signatures[i].Email), "signatories[" + i + "][email]");
+                        multipartContent.Add(new StringContent(signatures[i].TaxId), "signatories[" + i + "][tax_id]");
+                    }
+                }
+
                 return multipartContent;
             }
-            else if (!string.IsNullOrEmpty(originalHash) 
+            else if (!string.IsNullOrEmpty(originalHash)
                         && !string.IsNullOrEmpty(fileName))
             {
                 Dictionary<string, string> parameters = new Dictionary<string, string>();
@@ -115,7 +126,7 @@ namespace MifielAPI.Dao
                             "signatories[" + i + "][tax_id]", signatures[i].TaxId);
                     }
                 }
-                
+
                 return new FormUrlEncodedContent(parameters);
             }
             else

--- a/MifielAPI/MifielAPI/Utils/MifielUtils.cs
+++ b/MifielAPI/MifielAPI/Utils/MifielUtils.cs
@@ -31,7 +31,7 @@ namespace MifielAPI.Utils
             return _rgx.Replace(url, "");
         }
 
-        public static string GetDocunentHash(string path)
+        public static string GetDocumentHash(string path)
         {
             try
             {

--- a/MifielAPI/MifielApiTests/DocumentsTests.cs
+++ b/MifielAPI/MifielApiTests/DocumentsTests.cs
@@ -62,7 +62,7 @@ namespace MifielApiTests
         {
             SetSandboxUrl();
             Document doc = new Document();
-            doc.OriginalHash = MifielAPI.Utils.MifielUtils.GetDocunentHash(_pdfFilePath);
+            doc.OriginalHash = MifielAPI.Utils.MifielUtils.GetDocumentHash(_pdfFilePath);
             doc.FileName = "PdfFileName";
 
             doc = _docs.Save(doc);
@@ -104,7 +104,7 @@ namespace MifielApiTests
         {
             SetSandboxUrl();
             Document doc = new Document();
-            doc.OriginalHash = MifielAPI.Utils.MifielUtils.GetDocunentHash(_pdfFilePath);
+            doc.OriginalHash = MifielAPI.Utils.MifielUtils.GetDocumentHash(_pdfFilePath);
             doc.FileName = "PdfFileName";
             doc = _docs.Save(doc);
 
@@ -116,7 +116,7 @@ namespace MifielApiTests
         {
             SetSandboxUrl();
             Document doc = new Document();
-            doc.OriginalHash = MifielAPI.Utils.MifielUtils.GetDocunentHash(_pdfFilePath);
+            doc.OriginalHash = MifielAPI.Utils.MifielUtils.GetDocumentHash(_pdfFilePath);
             doc.FileName = "PdfFileName";
             doc = _docs.Save(doc);
 


### PR DESCRIPTION
-Considera signatories cuando existe document.File
-Corrección en el nombre del método MifielUtils.GetDocunentHash